### PR TITLE
Use commands for normal mode functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,50 @@ Plugin 'izzergh/rumpelstiltskin'
 
 # Customization
 
-The keybinds that start the fuzzy search can all be changed!
-Each subsection has a table. Here's how to use it:
+Normal mode and Insert mode keybinds are configurable in separate ways because
+  insert mode commands are weird and I don't quite get how to use them!
 
-In your runtime configuration or at runtime, set *variable* to some string other
-  than *default*.
-What that keybind will do is summarized in *description*.
+## Normal Mode
 
-For ease of editing, paste the following into your runtime configuration:
+Installing this plugin gives you the following commands:
+
+### Normal Mode Commands
+|Command|Description|
+|-|-|
+|`:RumpelCLDR`|Opens an FZF window to search the [CLDR](https://cldr.unicode.org/#h.59ffxi4tj4wz) set of Unicode characters|
+
+Example mapping:
 
 ```vim
-let g:rumpelstiltskin_cldr_i='<C-X>:'
-let g:rumpelstiltskin_cldr_n='<Leader>:'
+nmap <Leader>: :RumpelCLDR
 ```
 
-## CLDR keybinds
+## Insert Mode
+Insert mode is a little weird because I don't know how to do it better.
+The plugin provides the following public functions:
 
-|variable                  |default      |description                                             |
-|--------------------------|-------------|--------------------------------------------------------|
-|`g:rumpelstiltskin_cldr_i`|`'<C-X>:'`   |Fuzzy search in a pop-up from insert mode               |
-|`g:rumpelstiltskin_cldr_n`|`'<Leader>:'`|Fuzzy search in your default fzf window from normal mode|
+### Insert Mode Functions
+|Function|Description|
+|-|-|
+|`rumpelstiltskin#cldr_complete()`|Opens a mini FZF pop-up to search the [CLDR](https://cldr.unicode.org/#h.59ffxi4tj4wz) set of Unicode characters|
+
+These come with a default mapping (see table below) which can be overwritten
+  by assigning a string to the corresponding variable.
+
+### Insert Mode Variables
+|Variable|Corresponding function|Default value|
+|-|-|-|
+|`g:rumpelstiltskin_cldr_i`|`rumpelstiltskin#cldr_complete()`|`'<C-X>:'`|
+
+Customizing these looks like:
+
+```vim
+let g:rumpelstiltskin_cldr_i = ':cldr'
+```
+
+**NOTE** The way the insert mode customization works requires a restart of vim,
+  not just a `source`.
+This is the weirdness referred to earlier. Sorry! It's on the roadmap.
 
 # Demo
 Here's what it looks like! (I need to find one of them fancy screen-record-into-gif tools)

--- a/plugin/rumpelstiltskin.vim
+++ b/plugin/rumpelstiltskin.vim
@@ -5,13 +5,9 @@ endif
 
 " CLDR (unicode with text-to-speech names)
 " Normal mode
-if exists('g:rumpelstiltskin#cldr_n')
-  exec 'nmap ' . g:rumpelstiltskin#cldr_n . ' :rumpelstiltskin#cldr()l'
-else
-  nmap <Leader>: :call rumpelstiltskin#cldr()<CR>
-endif
+command! RumpelCLDR :call rumpelstiltskin#cldr()
 
-" Insert mode
+" Insert mode (currently requires restart to configure)
 if exists('g:rumpelstiltskin_cldr_i')
   exec 'imap <expr> ' . g:rumpelstiltskin_cldr_i . ' rumpelstiltskin#cldr_complete()'
 else


### PR DESCRIPTION
Using a command has the following bennies:

1. Easier to look at (`:RumpelCLDR` vs `:call rumpelstiltskin#cldr()`)
1. Mapping via runtime configuration doesn't require a restart
1. Easier to complete for those that don't want to use mappings, and instead
  want to try out the plugin by typing and relying on vim's command completion

Downside is a couple lines of code I guess, if I had to come up with one.

I was going to do the same for the insert mode function, but I couldn't figure
  out how to invoke a command from insert mode in the first place.
You can do `<C-O>` from insert mode to do One (1) normal mode thing, but that
  defeats the purpose of having an insert mode completion in the first place.

So, this halfway-addresses #4, and may be sufficient to close it if the other
  half remains infeasible (i.e. requires another approach entirely separate
  from the command system).

Anyway, this is a big step! We are excited!
